### PR TITLE
Improved socket access

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,6 +131,18 @@ socketPouchServer.listen(80, {
 });
 ```
 
+#### socketPouchServer.attach(server [, options] [, callback])
+
+##### Arguments
+
+* **server**: the engine.io server to attach to. This can be created in any of the three ways described in [their documentation](https://github.com/socketio/engine.io#a-listening-on-a-port).
+* **options**: (optional) options object
+  * **remoteUrl**: tells socket-pouch to act as a proxy for a remote CouchDB at the given URL (rather than creating local PouchDB databases)
+  * **pouchCreator**: alternatively, you can supply a custom function that takes a string and returns any PouchDB object however you like. (See examples below.) 
+  * **socketOptions**: (optional) options passed verbatim to Engine.io. See [their documentation](https://github.com/Automattic/engine.io/#methods) for details.
+* **callback**: (optional) called when the server has started
+
+
 ### Client
 
 ```js

--- a/README.md
+++ b/README.md
@@ -142,6 +142,16 @@ socketPouchServer.listen(80, {
   * **socketOptions**: (optional) options passed verbatim to Engine.io. See [their documentation](https://github.com/Automattic/engine.io/#methods) for details.
 * **callback**: (optional) called when the server has started
 
+```js
+var engine = require('engine.io');
+var engineServer = engine.listen(80);
+
+var socketPouchServer = require('socket-pouch/server');
+socketPouchServer.attach(engineServer);
+```
+
+All options and callbacks available on `listen` are available on `attach`.
+
 
 ### Client
 

--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ socketPouchServer.listen(80, {}, function () {
 * **port**: the port to listen on. You should probably use 80 or 443 if you plan on running this in production; most browsers are finicky about other ports. 8080 may work in Chrome during debugging.
 * **options**: (optional) options object
   * **remoteUrl**: tells socket-pouch to act as a proxy for a remote CouchDB at the given URL (rather than creating local PouchDB databases)
-  * **pouchCreator**: alternatively, you can supply a custom function that takes a string and returns any PouchDB object however you like. (See examples below.) 
+  * **pouchCreator**: alternatively, you can supply a custom function that takes the database name and the socket and returns any PouchDB object however you like. (See examples below.)
   * **socketOptions**: (optional) options passed verbatim to Engine.io. See [their documentation](https://github.com/Automattic/engine.io/#methods) for details.
 * **callback**: (optional) called when the server has started
 
@@ -107,7 +107,7 @@ Create a MemDOWN-backed PouchDB server:
 
 ```js
 socketPouchServer.listen(80, {
-  pouchCreator: function (dbName) {
+  pouchCreator: function (dbName, socket) {
     return new PouchDB(dbName, {
       db: require('memdown')
     });
@@ -121,7 +121,7 @@ Alternatively, your `pouchCreator` can return a `Promise` if you want to do some
 
 ```js
 socketPouchServer.listen(80, {
-  pouchCreator: function (dbName) {
+  pouchCreator: function (dbName, socket) {
     return doSomethingAsynchronously().then(function () {
       return {
         pouch: new PouchDB('dbname')
@@ -138,7 +138,7 @@ socketPouchServer.listen(80, {
 * **server**: the engine.io server to attach to. This can be created in any of the three ways described in [their documentation](https://github.com/socketio/engine.io#a-listening-on-a-port).
 * **options**: (optional) options object
   * **remoteUrl**: tells socket-pouch to act as a proxy for a remote CouchDB at the given URL (rather than creating local PouchDB databases)
-  * **pouchCreator**: alternatively, you can supply a custom function that takes a string and returns any PouchDB object however you like. (See examples below.) 
+  * **pouchCreator**: alternatively, you can supply a custom function that takes the database name and the socket and returns any PouchDB object however you like. (See examples below.)
   * **socketOptions**: (optional) options passed verbatim to Engine.io. See [their documentation](https://github.com/Automattic/engine.io/#methods) for details.
 * **callback**: (optional) called when the server has started
 

--- a/lib/server/index.js
+++ b/lib/server/index.js
@@ -316,9 +316,7 @@ function attach(server, options, callback) {
     options = {};
   }
   options = options || {};
-  var socketServer = engine.attach(server, options.socketOptions || {}, callback);
-
-  runSocketServer(socketServer, options);
+  runSocketServer(server, options);
 }
 
 module.exports = {

--- a/lib/server/index.js
+++ b/lib/server/index.js
@@ -280,9 +280,8 @@ function onReceiveBinaryMessage(message, socket) {
 }
 
 function runSocketServer(server, options) {
-  var pouchCreator = makePouchCreator(options);
-
   server.on('connection', function(socket) {
+    var pouchCreator = makePouchCreator(options, socket);
     socket.on('message', function (message) {
       if (typeof message !== 'string') {
         return onReceiveBinaryMessage(message, socket);
@@ -306,9 +305,9 @@ function listen(port, options, callback) {
     options = {};
   }
   options = options || {};
-  var server = engine.listen(port, options.socketOptions || {}, callback);
+  var socketServer = engine.listen(port, options.socketOptions || {}, callback);
 
-  runSocketServer(server, options);
+  runSocketServer(socketServer, options);
 }
 
 function attach(server, options, callback) {
@@ -317,9 +316,9 @@ function attach(server, options, callback) {
     options = {};
   }
   options = options || {};
-  var server = engine.attach(server, options.socketOptions || {}, callback);
+  var socketServer = engine.attach(server, options.socketOptions || {}, callback);
 
-  runSocketServer(server, options);
+  runSocketServer(socketServer, options);
 }
 
 module.exports = {

--- a/lib/server/index.js
+++ b/lib/server/index.js
@@ -279,14 +279,7 @@ function onReceiveBinaryMessage(message, socket) {
   }
 }
 
-function listen(port, options, callback) {
-  if (typeof options === 'function') {
-    callback = options;
-    options = {};
-  }
-  options = options || {};
-  var server = engine.listen(port, options.socketOptions || {}, callback);
-
+function runSocketServer(server, options) {
   var pouchCreator = makePouchCreator(options);
 
   server.on('connection', function(socket) {
@@ -307,6 +300,29 @@ function listen(port, options, callback) {
   });
 }
 
+function listen(port, options, callback) {
+  if (typeof options === 'function') {
+    callback = options;
+    options = {};
+  }
+  options = options || {};
+  var server = engine.listen(port, options.socketOptions || {}, callback);
+
+  runSocketServer(server, options);
+}
+
+function attach(server, options, callback) {
+  if (typeof options === 'function') {
+    callback = options;
+    options = {};
+  }
+  options = options || {};
+  var server = engine.attach(server, options.socketOptions || {}, callback);
+
+  runSocketServer(server, options);
+}
+
 module.exports = {
-  listen: listen
+  listen: listen,
+  attach: attach
 };

--- a/lib/server/make-pouch-creator.js
+++ b/lib/server/make-pouch-creator.js
@@ -4,7 +4,6 @@ var PouchDB = require('pouchdb');
 var Promise = require('bluebird');
 
 function createLocalPouch(args) {
-
   if (typeof args[0] === 'string') {
     args = [{name: args[0]}];
   }
@@ -32,7 +31,7 @@ function createHttpPouch(options) {
   };
 }
 
-function makePouchCreator(options) {
+function makePouchCreator(options, socket) {
   if (options.remoteUrl) {
     return createHttpPouch(options);
   }
@@ -41,7 +40,7 @@ function makePouchCreator(options) {
   }
   return function (args) {
     var name = typeof args[0] === 'string' ? args[0] : args[0].name;
-    var res = options.pouchCreator(name);
+    var res = options.pouchCreator(name, socket);
     if (res instanceof PouchDB) {
       return {pouch: res};
     } else {


### PR DESCRIPTION
Addresses #15 and #16 

In summary:
- Exposes the engine.io attach functionality as a new method on `module.exports` called attach that works the same way as listen with the first parameter as the engine server instead of the port number.
- Builds the `pouchCreator` for each connection so that the socket connection can be passed to the `pouchCreator` function. This will let users of the API develop authentication and other functionality.

I'm more than open to any feedback.

Edit: One thing I did note was that pouchCreator only seemed to work when returning a promise. I'll dig deeper in another issue. I'm embarrassed to say it took me far too long to work this out.
