### PR TITLE
Pass "auth" option (username + password)

### DIFF
--- a/lib/client/index.js
+++ b/lib/client/index.js
@@ -115,6 +115,9 @@ function SocketPouch(opts, callback) {
         name: api._name,
         auto_compaction: !!opts.auto_compaction
       };
+      if ('auth' in opts) {
+        serverOpts.auth = opts.auth;
+      }
       if ('revs_limit' in opts) {
         serverOpts.revs_limit = opts.revs_limit;
       }

--- a/lib/server/make-pouch-creator.js
+++ b/lib/server/make-pouch-creator.js
@@ -27,7 +27,9 @@ function createHttpPouch(options) {
       args = [{name: args[0]}];
     }
     var o={};
-    if (args[0].auth) o.auth=args[0].auth;
+    if (typeof args[0].auth !== 'undefined') {
+		o.auth=args[0].auth;
+	}
     return Promise.resolve({
       pouch: new PouchDB(remoteUrl + '/' + args[0].name,o)
     });

--- a/lib/server/make-pouch-creator.js
+++ b/lib/server/make-pouch-creator.js
@@ -27,7 +27,7 @@ function createHttpPouch(options) {
       args = [{name: args[0]}];
     }
     var o={};
-    if ('auth' in args[0]) o.auth=args[0].auth;
+    if (args[0].auth) o.auth=args[0].auth;
     return Promise.resolve({
       pouch: new PouchDB(remoteUrl + '/' + args[0].name,o)
     });

--- a/lib/server/make-pouch-creator.js
+++ b/lib/server/make-pouch-creator.js
@@ -26,8 +26,10 @@ function createHttpPouch(options) {
     if (typeof args[0] === 'string') {
       args = [{name: args[0]}];
     }
+    var o={};
+    if ('auth' in args[0]) o.auth=args[0].auth;
     return Promise.resolve({
-      pouch: new PouchDB(remoteUrl + '/' + args[0].name)
+      pouch: new PouchDB(remoteUrl + '/' + args[0].name,o)
     });
   };
 }
@@ -41,7 +43,7 @@ function makePouchCreator(options) {
   }
   return function (args) {
     var name = typeof args[0] === 'string' ? args[0] : args[0].name;
-    var res = options.pouchCreator(name);
+    var res = options.pouchCreator(name,args);
     if (res instanceof PouchDB) {
       return {pouch: res};
     } else {

--- a/lib/server/make-pouch-creator.js
+++ b/lib/server/make-pouch-creator.js
@@ -43,7 +43,7 @@ function makePouchCreator(options) {
   }
   return function (args) {
     var name = typeof args[0] === 'string' ? args[0] : args[0].name;
-    var res = options.pouchCreator(name,args);
+    var res = options.pouchCreator(name,args[0]);
     if (res instanceof PouchDB) {
       return {pouch: res};
     } else {


### PR DESCRIPTION
Pass _auth_ object to remote database, when _remoteUrl_ is set.
Pass options as second argument to _pouchCreator_.

PouchDB docs:
**auth.username + auth.password**: You can specify HTTP auth parameters either by using a database with a name in the form http://user:pass@host/name or via the auth.username + auth.password options.
