### PR TITLE
set type to 'http' to invoke http-ish behavior

### DIFF
--- a/lib/client/index.js
+++ b/lib/client/index.js
@@ -292,7 +292,8 @@ function SocketPouch(opts, callback) {
   }
 
   api.type = function () {
-    return 'socket';
+    // see https://github.com/pouchdb/pouchdb/issues/6106
+    return 'http';
   };
 
   api._id = adapterFun('id', function (callback) {


### PR DESCRIPTION
One good way to test interop issues with https://github.com/pouchdb/pouchdb/issues/6106 is to just change the `type()` to `'http
'` and see if the tests still pass.

If they do, this is a reasonable change for interop reasons, eve
n if it doesn't make much logical sense. The goal is just to inv
oke PouchDB behavior that is optimized for remote adapters, i.e.
 adapters where it's expensive to cross some kind of boundary (http, web sockets, worker, etc.).